### PR TITLE
feat(horizontal-navigation): adds drop shadow

### DIFF
--- a/src/static/sass/constants.scss
+++ b/src/static/sass/constants.scss
@@ -123,6 +123,7 @@ p {
       flex-direction: row;
       justify-content: center;
       padding-top: 50px;
+      box-shadow: 0 0 5px grey;
   }
   .h-nav-button {
     margin-left: 10px;


### PR DESCRIPTION
`.horizontal-navigation` when smaller than `750px` loses the drop shadow

my fix: adds that missing drop shadow.

why?: it doesn't make the white nav blend with the rest of the page

# here's a before...
<img width="575" alt="no bottom shadow on nav bar" src="https://cloud.githubusercontent.com/assets/6848941/26144608/54b88894-3a9e-11e7-9ccd-5eff1571b2b0.png">

# and after... 

<img width="575" alt="with bottom shadow on nav bar" src="https://cloud.githubusercontent.com/assets/6848941/26144611/5a228564-3a9e-11e7-8740-4e66a7041dc0.png">

